### PR TITLE
Corrected 'steamapps' in install.sh.

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -137,7 +137,10 @@ fi
 
 # Find PAYDAY 2
 
-PD2_DATA="$STEAM_LIBRARY/steamapps/common/PAYDAY 2"
+# Some steamapps folders are lowercase, some are PascalCase
+STEAMAPPS=$(find $STEAM_LIBRARY/ -maxdepth 1 -type d -iname steamapps)
+
+PD2_DATA="$STEAMAPPS/common/PAYDAY 2"
 LIB_INSTALLED=$PD2_DATA/libblt_loader.so
 
 if [ ! -d "$PD2_DATA" ]; then


### PR DESCRIPTION
~~Use of lowercase 'steamapps' caused the PD2 directory not to be found
when executing the install script. The SteamApps folder contains
capital letters, and linux is case-sensitive.~~

EDIT: Some installations appear to have lowercase 'steamapps', others 'SteamApps'. It's thought that older steam installations may suffer from PascalCase. This PR has been updated to include the use of 'find' for obtaining the correct steamapps directory for installing.