### PR TITLE
Fix dohttpreq randomly segfaulting when compiled on Clang

### DIFF
--- a/src/lapi_http.cc
+++ b/src/lapi_http.cc
@@ -11,7 +11,8 @@ namespace blt {
         using std::string;
 
         struct LUAHttpData {
-            int         funcRef;
+            int         funcRef
+                __attribute__((aligned(16))); // Why, Clang, Why! Using misaligned floating point ops for ints!
             int         progressRef;
             int         reqIdent;
             lua_state*  state;


### PR DESCRIPTION
When using dohttpreq on a copy of BLT4L compiled using Clang, the game will sometimes segfault (crash to desktop).

This is because Clang seems to be generating misaligned MOVAPS instructions when assigning a value to a member of the LUAHttpData struct, causing the segfaults.

Forcing the alignment of the first item in the first field of said struct seems to fix the issue; Testing 100 HTTP requests has not yet segfaulted.