### PR TITLE
Allow passing arguments through vm.xpcall, as per Lua 5.2

### DIFF
--- a/include/lua.hh
+++ b/include/lua.hh
@@ -59,6 +59,7 @@ extern "C" {
    void         lua_pushvalue(lua_state*, int);
    int          lua_isstring(lua_state*, int);
    void         lua_replace(lua_state*, int);
+   void         lua_remove(lua_state*, int);
    int          lua_error(lua_state*);
    int          lua_type(lua_state*, int);
 

--- a/src/lapi_vm.cc
+++ b/src/lapi_vm.cc
@@ -129,14 +129,17 @@ static int luaB_pcall (lua_State *L) {
 }
 
 static int luaB_xpcall (lua_State *L) {
-    int status;
+    // Args: func, err, ...
     luaL_checkany(L, 2);
-    lua_settop(L, 2);
-    lua_insert(L, 1);  /* put error function under function to be called */
-    status = lua_pcall(L, 0, LUA_MULTRET, 1);
+
+    lua_pushvalue(L, 2); // Copy err to the top
+    lua_remove(L, 2); // Remove err
+    lua_insert(L, 1); // Put error function under function to be called
+
+    int status = lua_pcall(L, lua_gettop(L) - 2, LUA_MULTRET, 1);
     lua_pushboolean(L, (status == 0));
-    lua_replace(L, 1);
-    return lua_gettop(L);  /* return status + all results */
+    lua_replace(L, 1); // Overwrite the error function
+    return lua_gettop(L);  // return status, possible err + all results
 }
 
 


### PR DESCRIPTION
Passing BLTUnit 223b0cb.