### PR TITLE
Add error.txt support, crash game on Lua error by default

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -38,6 +38,8 @@ set(SOURCE_FILES
     src/http.cc
     src/log.cc
     src/hook.cc
+    src/error.cc
+
     src/lapi.cc
     src/lapi_http.cc
     src/lapi_version.cc

--- a/README.md
+++ b/README.md
@@ -70,3 +70,44 @@ Run Payday2 with libblt_loader.so (It will crash, and SELinux will log the error
 $ sudo ausearch -c 'payday2_release' --raw | audit2allow -M my-payday2-hook
 $ sudo semodule -i my-payday-hook.pp
 ```
+
+Lua & Developer Information
+===========================
+
+##### Errors
+
+By default, any Lua error (outside of a pcall block) will immediately crash the game, and
+generate a error.txt file (found in mods/logs) containing the backtrace.
+
+In some situations, it might be useful to continue the game running despite the errors. In that
+case, set the `BLT_CRASH` environment variable to `CONTINUE`. This can be done by
+prepending `BLT_CRASH=CONTINUE` to the game launch arguments in Steam.
+
+##### Lua API
+
+BLT4L contains some additional Lua functions not present in windows PAYDAY.
+
+The first set of these are in the `vm` table, and are functions copied from Lua 5.1
+that are missing or have different behaviour in PAYDAY:
+
+* `vm.dofile`
+* `vm.loadfile`
+* `vm.load`
+* `vm.loadstring` (`loadstring` seems to be present in current versions, however)
+* `vm.pcall`
+* `vm.xpcall`
+
+The Linux version of PAYDAY is also missing a couple of key Lua APIs that are commonly used
+by mods.
+
+The first thing here is the `SystemFS` API. Many mods rely on this to save and load files. While
+BLT4L has added in some of these functions, it is very hard to determine the return types of some
+functions. Mods should use the Lua `io` table wherever possible.
+
+Many of the `DB` functions are missing - in particular, `DB:create_entry` is missing, which is
+how mods usually load custom assets (models, textures, etc) into the game. Work is (slowly) being done
+to reverse-engineer and reimplement this by @RomanHargrave and @ZNixian, however due to the difficulty of
+this task this will probably take a long time. As a result of this, custom heist/weapon/mask mods will
+not work (anything that goes into `mod_overrides` will still work, however).
+
+If you find any other Lua functions that are missing in BLT4L, please open an issue.

--- a/include/blt/error.hh
+++ b/include/blt/error.hh
@@ -1,0 +1,12 @@
+#include <string>
+
+#include "lua.hh"
+
+namespace blt {
+    namespace error {
+        int check_callback(lua_state*);
+    }
+}
+
+/* vim: set ts=4 softtabstop=0 sw=4 expandtab: */
+

--- a/include/lua.hh
+++ b/include/lua.hh
@@ -10,6 +10,7 @@ static int const LUAErrSyntax       = 3;
 static int const LUAErrMem          = 4;
 static int const LUAErrErr          = 5;
 static int const LUAErrFile         = 6;
+static int const LUAIdSize          = 60;
 
 class lua_state;
 typedef const char* (*lua_reader) (lua_state*, void*, size_t*);
@@ -19,6 +20,19 @@ typedef struct {
   const char* name;
   lua_cfunction func;
 } luaL_Reg;
+
+typedef struct lua_debug {
+   int event;
+   const char *name;           /* (n) */
+   const char *namewhat;       /* (n) */
+   const char *what;           /* (S) */
+   const char *source;         /* (S) */
+   int currentline;            /* (l) */
+   int nups;                   /* (u) number of upvalues */
+   int linedefined;            /* (S) */
+   int lastlinedefined;        /* (S) */
+   char short_src[LUAIdSize]; /* (S) */
+} lua_Debug;
 
 extern "C" {
    void         lua_call(lua_state*, int, int);
@@ -63,5 +77,10 @@ extern "C" {
    int          lua_error(lua_state*);
    int          lua_type(lua_state*, int);
 
+   int          lua_getinfo(lua_state*, const char*, lua_debug*);
+   int          lua_getstack(lua_state*, int, lua_debug*);
+
 }
+
+/* vim: set ts=3 softtabstop=0 sw=3 expandtab: */
 

--- a/src/error.cc
+++ b/src/error.cc
@@ -1,0 +1,100 @@
+#include "blt/error.hh"
+
+#include <string>
+#include <fstream>
+#include <sstream>
+#include <map>
+
+#include "blt/log.hh"
+
+namespace blt {
+    namespace error {
+        using std::string;
+        using std::endl;
+
+        std::map<lua_state*, int> refs;
+
+        // Based off the debug.traceback function
+        static void traceback (lua_state *L, void (print)(string)) {
+            lua_Debug ar;
+
+            int level = 1;
+
+            print("stack traceback:");
+            std::stringstream buff;
+            while (lua_getstack(L, level++, &ar)) {
+                buff << "\t";
+
+                lua_getinfo(L, "Snl", &ar);
+                buff << ar.short_src << ":";
+
+                if (ar.currentline > 0)
+                    buff << ar.currentline << ":";
+
+                if (*ar.namewhat != '\0')  /* is there a name? */
+                    buff << " in function '" << ar.name << "'";
+                else {
+                    if (*ar.what == 'm')  /* main? */
+                        buff << " in main chunk";
+                    else if (*ar.what == 'C' || *ar.what == 't')
+                        buff << " ?";  /* C function or tail call */
+                    else
+                        buff << " in function <" << ar.short_src << ":" << ar.linedefined << ">";
+                }
+
+                print(buff.str());
+                buff.str("");
+            }
+        }
+
+        static void errlog(string str) {
+            log::log(str, log::LOG_ERROR);
+        }
+
+        std::ofstream* crashstream;
+        static void crashlog(string str) {
+            *crashstream << str << endl;
+        }
+
+        static int error(lua_state* L) {
+            size_t len;
+
+            const char* crash_mode = getenv("BLT_CRASH");
+            if(crash_mode == NULL || string(crash_mode) != "CONTINUE")
+            {
+                std::ofstream info("mods/logs/crash.txt");
+                info << "Lua runtime error: " << lua_tolstring(L, 1, &len) << endl;
+                info << endl;
+                crashstream = &info;
+                traceback(L, crashlog);
+                info.close();
+
+                exit(1); // Does not return
+            }
+
+            log::log("lua_call: error in lua_pcall: " + string(lua_tolstring(L, 1, &len)), log::LOG_ERROR);
+            traceback(L, errlog);
+            log::log("End of stack trace\n", log::LOG_ERROR);
+
+            return 0;
+        }
+
+
+        int check_callback(lua_state* state) {
+            if(refs.count(state))
+                return refs[state];
+
+            lua_pushcclosure(state, &error, 0);
+            int ref = luaL_ref(state, LUARegistryIndex);
+            log::log("Type: " + std::to_string(lua_type(state, -1)));
+            log::log("ref: " + std::to_string(ref));
+
+            refs[state] = ref;
+
+            return ref;
+        }
+    }
+}
+
+/* vim: set ts=4 softtabstop=0 sw=4 expandtab: */
+

--- a/src/error.cc
+++ b/src/error.cc
@@ -15,14 +15,16 @@ namespace blt {
         std::map<lua_state*, int> refs;
 
         // Based off the debug.traceback function
-        static void traceback (lua_state *L, void (print)(string)) {
+        static void traceback (lua_state *L, void (print)(string))
+        {
             lua_Debug ar;
 
             int level = 1;
 
             print("stack traceback:");
             std::stringstream buff;
-            while (lua_getstack(L, level++, &ar)) {
+            while (lua_getstack(L, level++, &ar))
+            {
                 buff << "\t";
 
                 lua_getinfo(L, "Snl", &ar);
@@ -33,7 +35,8 @@ namespace blt {
 
                 if (*ar.namewhat != '\0')  /* is there a name? */
                     buff << " in function '" << ar.name << "'";
-                else {
+                else
+                {
                     if (*ar.what == 'm')  /* main? */
                         buff << " in main chunk";
                     else if (*ar.what == 'C' || *ar.what == 't')
@@ -47,16 +50,19 @@ namespace blt {
             }
         }
 
-        static void errlog(string str) {
+        static void errlog(string str)
+        {
             log::log(str, log::LOG_ERROR);
         }
 
         std::ofstream* crashstream;
-        static void crashlog(string str) {
+        static void crashlog(string str)
+        {
             *crashstream << str << endl;
         }
 
-        static int error(lua_state* L) {
+        static int error(lua_state* L)
+        {
             size_t len;
 
             const char* crash_mode = getenv("BLT_CRASH");
@@ -80,7 +86,8 @@ namespace blt {
         }
 
 
-        int check_callback(lua_state* state) {
+        int check_callback(lua_state* state)
+        {
             if(refs.count(state))
                 return refs[state];
 


### PR DESCRIPTION
See #93.

This will generate the error.txt file that provides a Lua backtrace of what caused a crash, and prevents save corruption in certain situations.