### PR TITLE
Update readme for compiling newer versions of BLT4L

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,9 +38,12 @@ Building & Manual Install
 * curl4-openssl (gnutls is NOT supported)
 * zlib
 * cmake
-* libc++dev
-* clang
 * a build tool chain (most distros have one preinstalled, or available in a build-essentials package)
+
+#### If you would like to compile BLT4L with custom asset-loading functionailty, which allows you to use certain custom masks and certain Custom HUDS, then you also require these extra prerequisites:
+
+* libc++dev
+* clang (3.8+)
 
 ##### Do the following:
 
@@ -54,6 +57,7 @@ $ cd build
 $ cmake -DUSE_LIBCXX=1 .. 
 $ make
 ```
+Note: If you opted to not install the extra prerequisites for custom asset-loading, then you can remove the variable ```-DUSE_LIBCXX=1``` from the cmake command.
 
 You should find the hook in your build folder, named `libblt_loader.so`.
 You will need to set `LD_PRELOAD` for the PAYDAY2 process to find the

--- a/README.md
+++ b/README.md
@@ -38,16 +38,20 @@ Building & Manual Install
 * curl4-openssl (gnutls is NOT supported)
 * zlib
 * cmake
+* libc++dev
+* clang
 * a build tool chain (most distros have one preinstalled, or available in a build-essentials package)
 
 ##### Do the following:
 
 ```
+$ git clone https://github.com/blt4linux/blt4l.git
+$ cd blt4l
 $ git submodule init
 $ git submodule update
 $ mkdir build 
 $ cd build
-$ cmake .. 
+$ cmake -DUSE_LIBCXX=1 .. 
 $ make
 ```
 


### PR DESCRIPTION
Updated Readme to add newest way of compiling BLT4L, which requires Libc++dev and a specific command to require clang for building the loader.